### PR TITLE
Use yq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ fetch-openapi:
 
 workaround-issue-18740:
 	# Workaround https://github.com/OpenAPITools/openapi-generator/pull/18740
-	jq 'del(.paths["/orgs/{orgId}/apps/{appId}/deltas"].post.responses["200"].content["application/json"].schema.oneOf.[] | select(.type == "string"))' ./docs/openapi.json > ./docs/openapi.patched.json
+	yq 'del(.paths["/orgs/{orgId}/apps/{appId}/deltas"].post.responses["200"].content["application/json"].schema.oneOf.[] | select(.type == "string"))' ./docs/openapi.json > ./docs/openapi.patched.json
 
 generate: workaround-issue-18740
 	rm -rf ./src/generated


### PR DESCRIPTION
The jq version installed on GHA has a bug that prevents us from patching the spec file.

```
jq 'del(.paths["/orgs/{orgId}/apps/{appId}/deltas"].post.responses["200"].content["application/json"].schema.oneOf.[] | select(.type == "string"))' ./docs/openapi.json > ./docs/openapi.patched.json
jq: error: syntax error, unexpected '[', expecting FORMAT or QQSTRING_START (Unix shell quoting issues?) at <top-level>, line 1:
del(.paths["/orgs/{orgId}/apps/{appId}/deltas"].post.responses["200"].content["application/json"].schema.oneOf.[] | select(.type == "string"))                                                                                                               
jq: 1 compile error
```

GHA currently has `jq 1.6` https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md and the expression only worked in 1.7+